### PR TITLE
Migrate script tag to JS file

### DIFF
--- a/javascripts/discourse/api-initializers/init-theme.js
+++ b/javascripts/discourse/api-initializers/init-theme.js
@@ -1,4 +1,6 @@
-<script type="text/discourse-plugin" version="0.8">
+import { apiInitializer } from "discourse/lib/api";
+
+export default apiInitializer((api) => {
   const user = api.getCurrentUser();
   const body = document.querySelector('body');
 
@@ -8,4 +10,4 @@
       .map((g) => `group-${g.id}`)
       .forEach((g) => body.classList.add(g));
   }
-</script>
+});


### PR DESCRIPTION
Migrates script from `header.html` to a JS file to address [inline script tag deprecation](https://meta.discourse.org/t/modernizing-inline-script-tags-for-templates-js-api/366482)

<img width="598" height="85" alt="Notice warning that adding JS code to Discourse themes using script tags is deprecated" src="https://github.com/user-attachments/assets/64bc3807-e54d-49b4-af64-8adab8e9b0fb" />
